### PR TITLE
Add UCPC 2026 material archive links

### DIFF
--- a/archive/ucpc/ucpc-2026/index.md
+++ b/archive/ucpc/ucpc-2026/index.md
@@ -22,6 +22,7 @@ title: UCPC 2026
 - 문제: [PDF (국문)](./qualifier/problem-ko.pdf), [PDF (영문)](./qualifier/problem-en.pdf)
 - 해설: [PDF](./qualifier/editorial.pdf)
 - 스코어보드: [HTML](./qualifier/scoreboard/)
+- 전체 자료: [ZIP](https://github.com/ucpcc/static/releases/download/archive-ucpc-v2026/v2026P.zip)
 
 ## 본선
 
@@ -34,6 +35,7 @@ title: UCPC 2026
 - 문제: [PDF (국문)](./final/problem-ko.pdf), [PDF (영문)](./final/problem-en.pdf)
 - 해설: [PDF](./final/editorial.pdf)
 - 스코어보드: [HTML](./final/scoreboard/)
+- 전체 자료: [ZIP](https://github.com/ucpcc/static/releases/download/archive-ucpc-v2026/v2026F.zip)
 - 다시 풀어보기: [Codeforces Gym](https://codeforces.com/gym/106618)
 
 ## 이동


### PR DESCRIPTION
## 어떤 작업을 했나요?

- UCPC 2026 예선·본선 전체 자료 ZIP 링크를 아카이브 페이지에 추가했습니다.
- `archive-ucpc-v2026` GitHub Release에 `v2026P.zip`, `v2026F.zip` asset을 업로드했습니다.
- 예선 12문제와 본선 14문제의 Polygon Full Linux 패키지를 대회 당시 문제 revision에 맞춰 구성했습니다.
- 총 982개 테스트 입력·정답과 ZIP 무결성을 확인했습니다.
- `jekyll build`로 페이지 빌드를 확인했습니다.

## 체크리스트

- [x] 아카이브에 자료를 추가하는 경우 [기여 문서](https://github.com/ucpcc/static/blob/main/archive/contribute.md)를 읽었으며, `권리 및 책임` 사항들에 동의합니다.
- [x] 파일과 경로를 확인했습니다.
- [x] 필요한 설명과 링크를 정리했습니다.
- [x] 공개 배포 또는 아카이브 수록에 필요한 권한을 확인했습니다.
- [x] 저작권, 라이선스, 기타 권리 관계상 문제가 없는지 확인했습니다.
